### PR TITLE
Prevent to install before Ruby 2.1.0

### DIFF
--- a/curses.gemspec
+++ b/curses.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new { |s|
   s.email = "shugo@ruby-lang.org"
   s.homepage = "http://github.com/shugo/curses"
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 2.1.0'
   s.summary = "curses binding for Ruby"
   s.files = Dir.glob('{lib,ext,sample}/**/*') + ['README.md', 'COPYING', 'BSDL']
   s.extensions = ["ext/curses/extconf.rb"]


### PR DESCRIPTION
Some people try to install curses gem to Ruby 1.9 and 2.0. I think better curses gem only support Ruby 2.1.0 later.
