### PR TITLE
Fix sample scripts shebang

### DIFF
--- a/sample/hello.rb
+++ b/sample/hello.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 
 require "curses"
 include Curses

--- a/sample/mouse.rb
+++ b/sample/mouse.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 
 require "curses"
 include Curses

--- a/sample/rain.rb
+++ b/sample/rain.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 # rain for a curses test
 
 require "curses"

--- a/sample/view.rb
+++ b/sample/view.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 
 require "curses"
 include Curses

--- a/sample/view2.rb
+++ b/sample/view2.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 
 require "curses"
 


### PR DESCRIPTION
I cloned the project to play with it locally.

Unfortunately sample scripts didn't work "out of the box" for 2 reasons:
- shebang line `#!/usr/local/bin/ruby` reported error (OS X 10.10)
- sample scripts aren't executable. The solution to this was to `chmod +x sample/*`.
