### PR TITLE
Update README; closes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 
 ## Description
 
-A Ruby binding for curses, ncurses, and PDCurses, formerly part of the Ruby
-standard library.   curses is an extension library for text UI applications.
+A Ruby binding for curses, ncurses, and PDCurses.
+curses is an extension library for text UI applications.
+
+Formerly part of the Ruby standard library, [curses was removed and placed in this gem][1]
+with the release of Ruby 2.1.0. (see [ruby/ruby@9c5b2fd][2])
 
 ## Install
 
@@ -26,3 +29,5 @@ and generate the RDoc.
 curses is released under the Ruby and 2-clause BSD licenses.  See COPYING for
 details.
 
+[1]: https://bugs.ruby-lang.org/issues/8584
+[2]: https://github.com/ruby/ruby/commit/9c5b2fd8aa0fd343ad094d47a638cfd3f6ae0a81


### PR DESCRIPTION
Add details on 'formerly part of the Ruby standard library'