### PR TITLE
Fix build on universal binary

### DIFF
--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -67,9 +67,7 @@ if header_library
     have_func(f) || (have_macro(f, curses) && $defs.push(format("-DHAVE_%s", f.upcase)))
   end
   flag = "-D_XOPEN_SOURCE_EXTENDED"
-  unless try_static_assert("sizeof(char*)<=sizeof(int)",
-                           %w[stdio.h stdlib.h]+curses,
-                           flag)
+  if try_compile(cpp_include(%w[stdio.h stdlib.h]+curses), flag, :werror => true)
     $defs << flag
   end
   have_var("ESCDELAY", curses)

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -67,9 +67,9 @@ if header_library
     have_func(f) || (have_macro(f, curses) && $defs.push(format("-DHAVE_%s", f.upcase)))
   end
   flag = "-D_XOPEN_SOURCE_EXTENDED"
-  if try_static_assert("sizeof(char*)>sizeof(int)",
-                       %w[stdio.h stdlib.h]+curses,
-                       flag)
+  unless try_static_assert("sizeof(char*)<=sizeof(int)",
+                           %w[stdio.h stdlib.h]+curses,
+                           flag)
     $defs << flag
   end
   have_var("ESCDELAY", curses)


### PR DESCRIPTION
With universal binary, `try_static_assert` succeeds when the given
expression is true on all architectures, `_XOPEN_SOURCE_EXTENDED`
macro is required when the expression is true on any architecture.
Invert the expression and `if`/`unless`.