### PR TITLE
Use chtype convertible int

### DIFF
--- a/ext/curses/curses.c
+++ b/ext/curses/curses.c
@@ -954,7 +954,7 @@ curses_bkgdset(VALUE obj, VALUE ch)
 {
 #ifdef HAVE_BKGDSET
     curses_stdscr();
-    bkgdset(NUM2ULONG(ch));
+    bkgdset(NUM2CHTYPE(ch));
 #endif
     return Qnil;
 }
@@ -975,7 +975,7 @@ curses_bkgd(VALUE obj, VALUE ch)
 {
 #ifdef HAVE_BKGD
     curses_stdscr();
-    return (bkgd(NUM2ULONG(ch)) == OK) ? Qtrue : Qfalse;
+    return (bkgd(NUM2CHTYPE(ch)) == OK) ? Qtrue : Qfalse;
 #else
     return Qfalse;
 #endif
@@ -2521,7 +2521,7 @@ window_bkgdset(VALUE obj, VALUE ch)
     struct windata *winp;
 
     GetWINDOW(obj,winp);
-    wbkgdset(winp->window, NUM2ULONG(ch));
+    wbkgdset(winp->window, NUM2CHTYPE(ch));
 #endif
     return Qnil;
 }
@@ -2542,7 +2542,7 @@ window_bkgd(VALUE obj, VALUE ch)
     struct windata *winp;
 
     GetWINDOW(obj,winp);
-    return (wbkgd(winp->window, NUM2ULONG(ch)) == OK) ? Qtrue : Qfalse;
+    return (wbkgd(winp->window, NUM2CHTYPE(ch)) == OK) ? Qtrue : Qfalse;
 #else
     return Qfalse;
 #endif

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -66,6 +66,7 @@ if header_library
               newpad unget_wch get_wch wget_wch)
     have_func(f) || (have_macro(f, curses) && $defs.push(format("-DHAVE_%s", f.upcase)))
   end
+  convertible_int('chtype', curses)
   flag = "-D_XOPEN_SOURCE_EXTENDED"
   if try_static_assert("sizeof(char*)>sizeof(int)",
                        %w[stdio.h stdlib.h]+curses,


### PR DESCRIPTION
Suppress shorten-64-to-32 "implicit conversion loses integer
precision" warnings on Mac OS.