### PR TITLE
`convertible_int` on mingw

### DIFF
--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -66,7 +66,7 @@ if header_library
               newpad unget_wch get_wch wget_wch)
     have_func(f) || (have_macro(f, curses) && $defs.push(format("-DHAVE_%s", f.upcase)))
   end
-  convertible_int('chtype', curses)
+  convertible_int('chtype', [["#undef MOUSE_MOVED\n"]]+curses) or abort
   flag = "-D_XOPEN_SOURCE_EXTENDED"
   if try_compile(cpp_include(%w[stdio.h stdlib.h]+curses), flag, :werror => true)
     $defs << flag
@@ -134,7 +134,7 @@ if header_library
   if enable_config("pdcurses-wide")
     $defs << '-DPDC_WIDE'
   end
-  
+
   if RUBY_VERSION >= '2.1'
     create_makefile("curses")
   else

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -68,7 +68,9 @@ if header_library
   end
   convertible_int('chtype', [["#undef MOUSE_MOVED\n"]]+curses) or abort
   flag = "-D_XOPEN_SOURCE_EXTENDED"
-  if try_compile(cpp_include(%w[stdio.h stdlib.h]+curses), flag, :werror => true)
+  if checking_for("_XOPEN_SOURCE_EXTENDED") {
+       try_compile(cpp_include(%w[stdio.h stdlib.h]+curses), flag, :werror => true)
+     }
     $defs << flag
   end
   have_var("ESCDELAY", curses)

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -138,6 +138,7 @@ if header_library
   end
 
   if RUBY_VERSION >= '2.1'
+    create_header
     create_makefile("curses")
   else
     # curses is part of ruby-core pre-2.1.0, so this gem is not required. But


### PR DESCRIPTION
Failed because `convetible_int` turned `MOUSE_MOVED` macro redefinition warning into an error.
And create `extconf.h` header to get rid of double quotes in `CPPFLAGS`, since msys `make` seems not working well.