### PR TITLE
Need to tell whether PDCurses is dll or not

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,7 @@ Rake::ExtensionTask.new(spec.name, spec) do |ext|
     ext.config_options << '--with-curses-include=' + 
       File.expand_path("vendor/PDCurses", __dir__) +
       ' --with-curses-version=function --enable-pdcurses-wide' +
+      ' --enable-pdcurses-dll' +
       ' --with-curses-lib=' +
       File.expand_path("vendor/#{RUBY_PLATFORM}/PDCurses", __dir__)
     spec.files += ["vendor/#{RUBY_PLATFORM}/PDCurses/pdcurses.dll"]

--- a/Rakefile
+++ b/Rakefile
@@ -27,13 +27,13 @@ namespace :build do
       if $mswin
         sh "nmake -f vcwin32.mak clean all WIDE=Y DLL=Y"
         cp %w[pdcurses.dll pdcurses.lib], "../../#{RUBY_PLATFORM}/PDCurses"
+      else
+        sh "make -f mingwin32.mak clean all _linux_w32=1 WIDE=Y DLL=Y"
+        cp "pdcurses.dll", "../../x86-mingw32/PDCurses"
+
+        sh "make -f mingwin32.mak clean all _linux_w64=1 WIDE=Y DLL=Y"
+        cp "pdcurses.dll", "../../x64-mingw32/PDCurses"
       end
-
-      sh "make -f mingwin32.mak clean all _linux_w32=1 WIDE=Y DLL=Y"
-      cp "pdcurses.dll", "../../x86-mingw32/PDCurses"
-
-      sh "make -f mingwin32.mak clean all _linux_w64=1 WIDE=Y DLL=Y"
-      cp "pdcurses.dll", "../../x64-mingw32/PDCurses"
     end
   end
 end

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -137,6 +137,10 @@ if header_library
     $defs << '-DPDC_WIDE'
   end
 
+  if enable_config("pdcurses-dll")
+    $defs << '-DPDC_DLL_BUILD'
+  end
+
   if RUBY_VERSION >= '2.1'
     create_header
     create_makefile("curses")


### PR DESCRIPTION
With VC++, we have to tell to linker that a referenced symbol is in DLL if
the symbol is not a function but a variable by using `__declspec(dllimport)`.
`curses.h` of PDCurses provides the way to declare symbols with it, but not
enabled by default.
Therefore, we have to tell it by defining `PDC_DLL_BUILD`.