### PR TITLE
Use `addnwstr` and `waddnwstr` if they are available

### DIFF
--- a/ext/curses/curses.c
+++ b/ext/curses/curses.c
@@ -138,7 +138,7 @@ prep_window(VALUE class, WINDOW *window)
     return obj;
 }
 
-#if defined(HAVE_ADDNWSTR) || defined(HAVE_WADDNWSTR)
+#if (defined(HAVE_ADDNWSTR) || defined(HAVE_WADDNWSTR)) && defined(_WIN32)
 static inline rb_encoding *
 get_wide_encoding(void)
 {
@@ -660,7 +660,7 @@ static VALUE
 curses_addstr(VALUE obj, VALUE str)
 {
     StringValue(str);
-#if defined(HAVE_ADDNWSTR)
+#if defined(HAVE_ADDNWSTR) && defined(_WIN32)
     str = rb_str_export_to_enc(str, get_wide_encoding());
     curses_stdscr();
     if (!NIL_P(str)) {
@@ -2138,7 +2138,7 @@ window_addstr(VALUE obj, VALUE str)
 	struct windata *winp;
 
 	StringValue(str);
-#if defined(HAVE_WADDNWSTR)
+#if defined(HAVE_WADDNWSTR) && defined(_WIN32)
 	str = rb_str_export_to_enc(str, get_wide_encoding());
 	GetWINDOW(obj, winp);
 	waddnwstr(winp->window, (wchar_t *)RSTRING_PTR(str), RSTRING_LEN(str) / sizeof(wchar_t));

--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -57,9 +57,9 @@ if header_library
 
   for f in %w(beep bkgd bkgdset curs_set deleteln doupdate flash
               getbkgd getnstr init isendwin keyname keypad resizeterm
-              scrl set setscrreg ungetch
+              scrl set setscrreg ungetch addnwstr
               wattroff wattron wattrset wbkgd wbkgdset wdeleteln wgetnstr
-              wresize wscrl wsetscrreg werase redrawwin
+              wresize wscrl wsetscrreg werase redrawwin waddnwstr
               touchwin untouchwin wtouchln is_linetouched is_wintouched
               def_prog_mode reset_prog_mode timeout wtimeout nodelay
               init_color wcolor_set use_default_colors assume_default_colors


### PR DESCRIPTION
In old implementation, we convert the passed string to terminal_encoding and
pass the result to `addstr` or `waddstr`.
If using PDCurses, in `addstr` and `waddstr` the passed string is converted to
wide char by using `mbstows`.
But `mbstows` requires to call `setlocale` to know the encoding of passed
multibyte string.
Since `setlocale` affects entire process, we cannot call it only for this
purpose.
Then we have to convert the original string to wide char by ourselves and pass
the result to wide string APIs of curses.