### PR TITLE
Favor ncursesw over curses

### DIFF
--- a/curses.gemspec
+++ b/curses.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new { |s|
   s.name = "curses"
-  s.version = "1.2.5"
+  s.version = "1.2.4"
   s.author = ["Shugo Maeda", 'Eric Hodel']
   s.email = ["shugo@ruby-lang.org", 'drbrain@segment7.net']
   s.homepage = "https://github.com/ruby/curses"

--- a/curses.gemspec
+++ b/curses.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new { |s|
   s.name = "curses"
-  s.version = "1.2.4"
+  s.version = "1.2.5"
   s.author = ["Shugo Maeda", 'Eric Hodel']
   s.email = ["shugo@ruby-lang.org", 'drbrain@segment7.net']
   s.homepage = "https://github.com/ruby/curses"

--- a/ext/curses/curses.c
+++ b/ext/curses/curses.c
@@ -20,12 +20,12 @@
 #include "ruby/io.h"
 #include "ruby/thread.h"
 
-#if defined(HAVE_NCURSES_H)
-# include <ncurses.h>
-#elif defined(HAVE_NCURSESW_CURSES_H)
+#if defined(HAVE_NCURSESW_CURSES_H)
 # include <ncursesw/curses.h>
 #elif defined(HAVE_NCURSES_CURSES_H)
 # include <ncurses/curses.h>
+#elif defined(HAVE_NCURSES_H)
+# include <ncurses.h>
 #elif defined(HAVE_CURSES_COLR_CURSES_H)
 # ifdef HAVE_STDARG_PROTOTYPES
 #  include <stdarg.h>


### PR DESCRIPTION
When ncursesw is available on a platform, you gain wide-character support (e.g. for [box drawing characters](https://en.wikipedia.org/wiki/Box-drawing_character)) on Debian Linux machines if that's prioritized over the standard curses library (which will only print "garbage", as far as the user is concerned).

Since the API is compatible and ncursesw is supported by this gem, I think we should default to ncursesw instead.