### PR TITLE
Added samples for addch, attron, mouse tracking and colors

### DIFF
--- a/ext/curses/curses.c
+++ b/ext/curses/curses.c
@@ -85,6 +85,17 @@
 #define NUM2CH NUM2CHR
 #define CH2FIX CHR2FIX
 
+#define OBJ2CHTYPE rb_obj2chtype_inline
+
+static inline chtype
+rb_obj2chtype_inline(VALUE x)
+{
+    if (RB_TYPE_P(x, RUBY_T_STRING) && (RSTRING_LEN(x)>=1))
+        return RSTRING_PTR(x)[0];
+    else
+        return NUM2CHTYPE(x);
+}
+
 static VALUE mCurses;
 static VALUE mKey;
 static VALUE cWindow;
@@ -762,7 +773,7 @@ static VALUE
 curses_addch(VALUE obj, VALUE ch)
 {
     curses_stdscr();
-    addch(NUM2CH(ch));
+    addch(OBJ2CHTYPE(ch));
     return Qnil;
 }
 
@@ -777,7 +788,7 @@ static VALUE
 curses_insch(VALUE obj, VALUE ch)
 {
     curses_stdscr();
-    insch(NUM2CH(ch));
+    insch(OBJ2CHTYPE(ch));
     return Qnil;
 }
 
@@ -2286,7 +2297,7 @@ window_addch(VALUE obj, VALUE ch)
     struct windata *winp;
 
     GetWINDOW(obj, winp);
-    waddch(winp->window, NUM2CH(ch));
+    waddch(winp->window, NUM2CHTYPE(ch));
 
     return Qnil;
 }

--- a/sample/addch.rb
+++ b/sample/addch.rb
@@ -1,0 +1,16 @@
+require_relative "../lib/curses"
+include Curses
+
+init_screen
+begin
+  addstr("The following letter A should be BOLD and UNDERLINED by using addch:\n")
+  addch('A'.ord | A_BOLD | A_UNDERLINE)
+
+  addstr("\nIt should look the same as when using attron and addstr:\n")
+  attron(A_BOLD | A_UNDERLINE)
+  addstr("A")
+  getch
+
+ensure
+  close_screen
+end

--- a/sample/attr_demo.rb
+++ b/sample/attr_demo.rb
@@ -1,0 +1,32 @@
+require "curses"
+include Curses
+
+init_screen
+begin
+  attrs = {
+    A_NORMAL =>     'Normal display (no highlight)',
+    A_STANDOUT =>   'Best highlighting mode of the terminal',
+    A_UNDERLINE =>  'Underlining',
+    A_REVERSE =>    'Reverse video',
+    A_BLINK =>      'Blinking',
+    A_DIM =>        'Half bright',
+    A_BOLD =>       'Extra bright or bold',
+    A_PROTECT =>    'Protected mode',
+    A_INVIS =>      'Invisible or blank mode',
+    A_ALTCHARSET => 'Alternate character set',
+  }
+
+  longest_description = attrs.values.map(&:size).max
+  attrs.each { |attribute, description|
+
+    attrset(A_NORMAL)
+    addstr("#{description.ljust(longest_description)}: ")
+
+    attrset(attribute)
+    addstr([*('a'..'z'), *('0'..'9')].join + "\n")
+  }
+  getch
+
+ensure
+  close_screen
+end

--- a/sample/colors.rb
+++ b/sample/colors.rb
@@ -1,0 +1,26 @@
+require "curses"
+include Curses
+
+begin
+  init_screen
+
+  if !Curses.has_colors?
+    addstr "This Terminal does not support colors!"
+  else
+    start_color
+
+    addstr "This Terminal supports #{colors} colors.\n"
+
+    Curses.colors.times { |i|
+      Curses.init_pair(i, i, 0)
+      attrset(color_pair(i))
+      addstr("#{i.to_s.rjust(3)} ")
+      addstr("\n") if i == 15 || (i > 16 && (i - 15) % 36 == 0)
+    }
+  end
+
+  getch
+
+ensure
+  close_screen
+end

--- a/sample/mouse_move.rb
+++ b/sample/mouse_move.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+#
+# Mouse movement tracking using CSI 1003 and 1006 (SGR). Will print a cursor that moves with the mouse.
+#
+
+require "curses"
+include Curses
+
+@positions = []
+
+def draw_cursor(y, x, button, state)
+
+  # Keep a trail of 10 previous positions visible on the screen
+  if @positions.size >= 10
+    y_old, x_old = @positions.shift
+    setpos(y_old, x_old)
+    addstr(" ")
+  end
+
+  setpos(2, 1)
+  addstr("Mouse is at y=#{y.to_s.ljust(3)} x=#{x.to_s.ljust(3)} button=#{button.to_s.ljust(3)} #{'%08b' % button}")
+
+  setpos(y, x)
+  addstr("+")
+  @positions << [y, x]
+end
+
+init_screen
+crmode
+noecho
+stdscr.box('|', "-")
+setpos(1,1)
+addstr("Please move your mouse. Press 'q' to close.")
+
+begin
+  # Switch on mouse continous position reporting
+  print("\x1b[?1003h")
+
+  # Also enable SGR extended reporting, because otherwise we can only
+  # receive values up to 160x94. Everything else confuses Ruby Curses.
+  print("\x1b[?1006h")
+
+  loop do
+    c = get_char
+    case c
+    when "q"
+      return
+    when "\e" # ESC
+      case get_char
+      when '['
+        csi = ""
+        loop do
+          d = get_char
+          csi += d
+          if d.ord >= 0x40 && d.ord <= 0x7E
+            break
+          end
+        end
+        if /<(\d+);(\d+);(\d+)(m|M)/ =~ csi
+          button = $1.to_i
+          x = $2.to_i
+          y = $3.to_i
+          state = $4
+          draw_cursor(y, x, button, state)
+        end
+      end
+    end
+  end
+
+ensure
+  print("\x1b[?1003l")
+  print("\x1b[?1006l")
+  close_screen
+end
+


### PR DESCRIPTION
Additional samples which demonstrate various functions of curses:

- addch: How to add styled characters.
- colors: How to test if colors are supported and print them.
- mouse_move: How to capture mouse move events and enable CSI mode.
- attr_demo: Sample which shows each standard style.