### PR TITLE
Add MacOS directives to install curses with menu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ However, if you prefer ncurses to PDCurses, specify the following option:
 
 On mingw, you need DevKit to compile the extension library.
 
+On MacOS, `ncurses` menu isn't natively supported. You can install the gem with menu support using homebrew:
+
+    brew install ncurses
+    gem install curses -- --use-system-libraries --with-ncurses-dir=/usr/local/opt/ncurses
+
+_with `/usr/local/opt/ncurses` the path where homebrew installed ncurses on your machine_
+
 ## Documentation
 
 See [https://www.rubydoc.info/gems/curses](https://www.rubydoc.info/gems/curses).


### PR DESCRIPTION
Fixes #83 

It seems that macos ncurses menu isn't supported by default. Using homebrew libraries with ncurses solve this problem.

https://stackoverflow.com/questions/56622042/clang-on-macos-fails-linking-lmenu-from-ncurses