### PR TITLE
Use -std=gnu17 to avoid C23 errors

### DIFF
--- a/ext/curses/extconf.rb
+++ b/ext/curses/extconf.rb
@@ -67,11 +67,8 @@ if $use_bundled_pdcurses
       FileUtils.cp("pdcurses.lib", pdcurses_dir)
       $pdcurses_dll_default = true
     else
-      if $x64
-        exec_command "make -f Makefile.mng clean all _w64=1 WIDE=Y DLL=N"
-      else
-        exec_command "make -f Makefile.mng clean all WIDE=Y DLL=N"
-      end
+      w64 = $x64 ? "_w64=1" : ""
+      exec_command "make -f Makefile.mng clean all #{w64} WIDE=Y DLL=N CC=\"gcc -std=gnu17\""
       FileUtils.cp("pdcurses.a", File.expand_path("libpdcurses.a", pdcurses_dir))
     end
   ensure


### PR DESCRIPTION
```
gcc -c -O4 -Wall -pedantic -I.. -DPDC_WIDE ../pdcurses/addch.c
In file included from ../curspriv.h:10,
                 from ../pdcurses/addch.c:3:
../curses.h:86:23: error: 'bool' cannot be defined via 'typedef'
   86 | typedef unsigned char bool;
      |                       ^~~~
../curses.h:86:23: note: 'bool' is a keyword with '-std=c23' onwards
../curses.h:86:1: warning: useless type name in empty declaration
   86 | typedef unsigned char bool;
      | ^~~~~~~
```