### PR TITLE
Specify need to install rubygems-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ _with `/usr/local/opt/ncurses` the path where homebrew installed ncurses on your
 
 Type the following command, and see `[rdoc]` of curses:
 
-    > gem server -l
+    gem install rubygems-server
+    gem server -l
 
 ## Limitations
 


### PR DESCRIPTION
The error message if you don't have rubygems-server uninstalled is very unhelpful, this will help people out I think.